### PR TITLE
https for http in google fonts.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,6 +25,6 @@
 	<script src="/build/mediaelement-and-player.min.js"></script>
 	<link rel="stylesheet" href="/build/mediaelementplayer.min.css" />
 
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 
 </head>


### PR DESCRIPTION
Because of https://developer.mozilla.org/ru/docs/Security/MixedContent